### PR TITLE
fix on morpion example

### DIFF
--- a/demo/morpion/hom/const.hpp
+++ b/demo/morpion/hom/const.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cmath>
+#include <cstddef>
 
 extern size_t NBCELL;
 extern int STATE_SYSTEM_CELL;


### PR DESCRIPTION
Correction of a compilation bug for the morpion demo example, in which the type "size_t" was not recognized.

